### PR TITLE
Harmonizes SchemaConfig to a named block structure

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -23,9 +23,8 @@
           }
         }
       },
-      "exporters": [
-        {
-          "name": "thumbnail",
+      "exporters": {
+        "thumbnail": {
           "factory": "ThumbnailExporter",
           "resolverName": "disk",
           "parameters": {
@@ -33,8 +32,7 @@
             "mimeType": "JPG"
           }
         },
-        {
-          "name": "preview",
+        "preview": {
           "factory": "VideoPreviewExporter",
           "resolverName": "disk",
           "parameters": {
@@ -43,7 +41,7 @@
             "previewTimeSec": "5"
           }
         }
-      ],
+      },
       "extractionPipelines": [
         {
           "name": "ingestion",

--- a/config-schema.json
+++ b/config-schema.json
@@ -9,24 +9,12 @@
           "port": "1865"
         }
       },
-      "fields": [
-        {
-          "name": "averagecolor",
-          "factory": "AverageColor"
-        },
-        {
-          "name": "file",
-          "factory": "FileSourceMetadata"
-        },
-        {
-          "name": "time",
-          "factory": "TemporalMetadata"
-        },
-        {
-          "name": "video",
-          "factory": "VideoSourceMetadata"
-        }
-      ],
+      "fields": {
+        "averagecolor": { "factory": "AverageColor" },
+        "file": { "factory": "FileSourceMetadata" },
+        "time": { "factory":  "TemporalMetadata" },
+        "video": { "factory":  "VideoSourceMetadata" }
+      },
       "resolvers": {
         "disk": {
           "factory": "DiskResolver",

--- a/config-schema.json
+++ b/config-schema.json
@@ -1,7 +1,6 @@
 {
-  "schemas": [
-    {
-      "name": "vitrivr",
+  "schemas": {
+    "vitrivr": {
       "connection": {
         "database": "CottontailConnectionProvider",
         "parameters": {
@@ -10,10 +9,18 @@
         }
       },
       "fields": {
-        "averagecolor": { "factory": "AverageColor" },
-        "file": { "factory": "FileSourceMetadata" },
-        "time": { "factory":  "TemporalMetadata" },
-        "video": { "factory":  "VideoSourceMetadata" }
+        "averagecolor": {
+          "factory": "AverageColor"
+        },
+        "file": {
+          "factory": "FileSourceMetadata"
+        },
+        "time": {
+          "factory": "TemporalMetadata"
+        },
+        "video": {
+          "factory": "VideoSourceMetadata"
+        }
       },
       "resolvers": {
         "disk": {
@@ -43,8 +50,10 @@
         }
       },
       "extractionPipelines": {
-        "ingestion": { "path": "./config-ingestion.json" }
+        "ingestion": {
+          "path": "./config-ingestion.json"
+        }
       }
     }
-  ]
+  }
 }

--- a/config-schema.json
+++ b/config-schema.json
@@ -42,12 +42,9 @@
           }
         }
       },
-      "extractionPipelines": [
-        {
-          "name": "ingestion",
-          "path": "./config-ingestion.json"
-        }
-      ]
+      "extractionPipelines": {
+        "ingestion": { "path": "./config-ingestion.json" }
+      }
     }
   ]
 }

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/ExporterConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/ExporterConfig.kt
@@ -11,10 +11,6 @@ import org.vitrivr.engine.core.resolver.Resolver
 @Serializable
 data class ExporterConfig(
     /**
-     * The name of the [Exporter].
-     */
-    val name: String,
-    /**
      * The simple or fully qualified class name of the [ExporterFactory]
      */
     val factory: String,

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/FieldConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/FieldConfig.kt
@@ -12,4 +12,4 @@ import org.vitrivr.engine.core.model.metamodel.Schema
  * @version 1.0.0
  */
 @Serializable
-data class FieldConfig(val name: String, val factory: String, val parameters: Map<String,String> = emptyMap(), val indexes: List<IndexConfig> = emptyList())
+data class FieldConfig(val factory: String, val parameters: Map<String,String> = emptyMap(), val indexes: List<IndexConfig> = emptyList())

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/PipelineConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/PipelineConfig.kt
@@ -4,6 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PipelineConfig(
-    val name: String,
     val path: String,
 )

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
@@ -2,6 +2,8 @@ package org.vitrivr.engine.core.config.schema
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
 import org.vitrivr.engine.core.model.metamodel.Schema
 import org.vitrivr.engine.core.operators.general.Exporter
 import org.vitrivr.engine.core.resolver.Resolver
@@ -62,6 +64,11 @@ data class SchemaConfig(
             val path = Paths.get(uri)
             val jsonString = Files.readString(path)
             return json.decodeFromString<SchemaConfig>(jsonString)
+        }
+
+        fun fromJsonWithName(jsonElement: JsonElement, name: String): SchemaConfig {
+            val schemaConfig = Json.decodeFromJsonElement(SchemaConfig.serializer(), jsonElement)
+            return schemaConfig.copy(name = name)
         }
     }
 }

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 @Serializable
 data class SchemaConfig(
     /** Name of the [Schema]. */
-    val name: String = "vitrivr",
+    var name: String = "vitrivr",
 
     /** The (database) [ConnectionConfig] for this [SchemaConfig]. */
     val connection: ConnectionConfig,

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
@@ -40,7 +40,7 @@ data class SchemaConfig(
      * List of [ExporterConfig]s that are part of this [SchemaConfig].
      * @see Exporter
      */
-    val exporters: List<ExporterConfig> = emptyList(),
+    val exporters: Map<String, ExporterConfig> = emptyMap(),
 
     /**
      * List of [PipelineConfig]s that are part of this [SchemaConfig].

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
@@ -2,8 +2,6 @@ package org.vitrivr.engine.core.config.schema
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.decodeFromJsonElement
 import org.vitrivr.engine.core.model.metamodel.Schema
 import org.vitrivr.engine.core.operators.general.Exporter
 import org.vitrivr.engine.core.resolver.Resolver
@@ -64,11 +62,6 @@ data class SchemaConfig(
             val path = Paths.get(uri)
             val jsonString = Files.readString(path)
             return json.decodeFromString<SchemaConfig>(jsonString)
-        }
-
-        fun fromJsonWithName(jsonElement: JsonElement, name: String): SchemaConfig {
-            val schemaConfig = Json.decodeFromJsonElement(SchemaConfig.serializer(), jsonElement)
-            return schemaConfig.copy(name = name)
         }
     }
 }

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
@@ -45,7 +45,7 @@ data class SchemaConfig(
     /**
      * List of [PipelineConfig]s that are part of this [SchemaConfig].
      */
-    val extractionPipelines: List<PipelineConfig> = emptyList()
+    val extractionPipelines: Map<String, PipelineConfig> = emptyMap()
 ) {
 
     companion object {

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/config/schema/SchemaConfig.kt
@@ -28,7 +28,7 @@ data class SchemaConfig(
     /**
      * List of [FieldConfig]s that are part of this [SchemaConfig].
      */
-    val fields: List<FieldConfig>,
+    val fields: Map<String, FieldConfig>,
 
     /**
      * The list of [ResolverConfig]s that are part of this [SchemaConfig].

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
@@ -49,13 +49,13 @@ class SchemaManager {
         /* Create new connection using reflection. */
         val connection = connectionProvider.openConnection(config.name, config.connection.parameters)
         val schema = Schema(config.name, connection)
-        config.fields.map {
-            val analyser = loadServiceForName<Analyser<*,*>>(it.factory) ?: throw IllegalArgumentException("Failed to find a factory implementation for '${it.factory}'.")
-            if(it.name.contains(".")){
+        config.fields.forEach { (name, fieldConfig) ->
+            val analyser = loadServiceForName<Analyser<*,*>>(fieldConfig.factory) ?: throw IllegalArgumentException("Failed to find a factory implementation for '${fieldConfig.factory}'.")
+            if(name.contains(".")){
                 throw IllegalArgumentException("Field names must not have a dot (.) in their name.")
             }
             @Suppress("UNCHECKED_CAST")
-            schema.addField(it.name, analyser as Analyser<ContentElement<*>, Descriptor>, it.parameters, it.indexes)
+            schema.addField(name, analyser as Analyser<ContentElement<*>, Descriptor>, fieldConfig.parameters, fieldConfig.indexes)
         }
         config.resolvers.map {
             schema.addResolver(it.key, (loadServiceForName<ResolverFactory>(it.value.factory) ?: throw IllegalArgumentException("Failed to find resolver factory implementation for '${it.value.factory}'.")).newResolver(schema, it.value.parameters))

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
@@ -60,12 +60,12 @@ class SchemaManager {
         config.resolvers.map {
             schema.addResolver(it.key, (loadServiceForName<ResolverFactory>(it.value.factory) ?: throw IllegalArgumentException("Failed to find resolver factory implementation for '${it.value.factory}'.")).newResolver(schema, it.value.parameters))
         }
-        config.exporters.map {
+        config.exporters.forEach { (name, exporterConfig) ->
             schema.addExporter(
-                it.name,
-                loadServiceForName<ExporterFactory>(it.factory) ?: throw IllegalArgumentException("Failed to find exporter factory implementation for '${it.factory}'."),
-                it.parameters,
-                it.resolverName
+                name,
+                loadServiceForName<ExporterFactory>(exporterConfig.factory) ?: throw IllegalArgumentException("Failed to find exporter factory implementation for '${exporterConfig.factory}'."),
+                exporterConfig.parameters,
+                exporterConfig.resolverName
             )
         }
         config.extractionPipelines.map {

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
@@ -81,6 +81,11 @@ class SchemaManager {
         this.schemas[schema.name] = schema
     }
 
+    fun load(name: String, config: SchemaConfig) {
+        config.name = name
+        load(config)
+    }
+
     /**
      * Lists all [Schema] managed by this [SchemaManager].
      *

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
@@ -68,13 +68,13 @@ class SchemaManager {
                 exporterConfig.resolverName
             )
         }
-        config.extractionPipelines.map {
-            val ingestionConfig = IngestionConfig.read(Paths.get(it.path))
-                ?: throw IllegalArgumentException("Failed to read pipeline configuration from '${it.path}'.")
+        config.extractionPipelines.forEach() {(name, extractionPipelineConfig) ->
+            val ingestionConfig = IngestionConfig.read(Paths.get(extractionPipelineConfig.path))
+                ?: throw IllegalArgumentException("Failed to read pipeline configuration from '${extractionPipelineConfig.path}'.")
             if (ingestionConfig.schema != schema.name) {
                 throw IllegalArgumentException("Schema name in pipeline configuration '${ingestionConfig.schema}' does not match schema name '${schema.name}'.")
             }
-            schema.addIngestionPipeline(it.name, ingestionConfig)
+            schema.addIngestionPipeline(name, ingestionConfig)
         }
 
         /* Cache and return connection. */

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
@@ -81,6 +81,12 @@ class SchemaManager {
         this.schemas[schema.name] = schema
     }
 
+    /**
+     * Sets the name for a [SchemaConfig], then calls load.
+     *
+     * @param name The name of the schema.
+     * @param config The [SchemaConfig] to which to assign the name and load.
+     */
     fun load(name: String, config: SchemaConfig) {
         config.name = name
         load(config)

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
@@ -49,32 +49,32 @@ class SchemaManager {
         /* Create new connection using reflection. */
         val connection = connectionProvider.openConnection(config.name, config.connection.parameters)
         val schema = Schema(config.name, connection)
-        config.fields.forEach { (name, fieldConfig) ->
+        config.fields.forEach { (fieldName, fieldConfig) ->
             val analyser = loadServiceForName<Analyser<*,*>>(fieldConfig.factory) ?: throw IllegalArgumentException("Failed to find a factory implementation for '${fieldConfig.factory}'.")
-            if(name.contains(".")){
+            if(fieldName.contains(".")){
                 throw IllegalArgumentException("Field names must not have a dot (.) in their name.")
             }
             @Suppress("UNCHECKED_CAST")
-            schema.addField(name, analyser as Analyser<ContentElement<*>, Descriptor>, fieldConfig.parameters, fieldConfig.indexes)
+            schema.addField(fieldName, analyser as Analyser<ContentElement<*>, Descriptor>, fieldConfig.parameters, fieldConfig.indexes)
         }
-        config.resolvers.forEach { (name, resolverConfig) ->
-            schema.addResolver(name, (loadServiceForName<ResolverFactory>(resolverConfig.factory) ?: throw IllegalArgumentException("Failed to find resolver factory implementation for '${resolverConfig.factory}'.")).newResolver(schema, resolverConfig.parameters))
+        config.resolvers.forEach { (resolverName, resolverConfig) ->
+            schema.addResolver(resolverName, (loadServiceForName<ResolverFactory>(resolverConfig.factory) ?: throw IllegalArgumentException("Failed to find resolver factory implementation for '${resolverConfig.factory}'.")).newResolver(schema, resolverConfig.parameters))
         }
-        config.exporters.forEach { (name, exporterConfig) ->
+        config.exporters.forEach { (exporterName, exporterConfig) ->
             schema.addExporter(
-                name,
+                exporterName,
                 loadServiceForName<ExporterFactory>(exporterConfig.factory) ?: throw IllegalArgumentException("Failed to find exporter factory implementation for '${exporterConfig.factory}'."),
                 exporterConfig.parameters,
                 exporterConfig.resolverName
             )
         }
-        config.extractionPipelines.forEach {(name, extractionPipelineConfig) ->
+        config.extractionPipelines.forEach { (extractionPipelineName, extractionPipelineConfig) ->
             val ingestionConfig = IngestionConfig.read(Paths.get(extractionPipelineConfig.path))
                 ?: throw IllegalArgumentException("Failed to read pipeline configuration from '${extractionPipelineConfig.path}'.")
             if (ingestionConfig.schema != schema.name) {
                 throw IllegalArgumentException("Schema name in pipeline configuration '${ingestionConfig.schema}' does not match schema name '${schema.name}'.")
             }
-            schema.addIngestionPipeline(name, ingestionConfig)
+            schema.addIngestionPipeline(extractionPipelineName, ingestionConfig)
         }
 
         /* Cache and return connection. */

--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/SchemaManager.kt
@@ -57,8 +57,8 @@ class SchemaManager {
             @Suppress("UNCHECKED_CAST")
             schema.addField(name, analyser as Analyser<ContentElement<*>, Descriptor>, fieldConfig.parameters, fieldConfig.indexes)
         }
-        config.resolvers.map {
-            schema.addResolver(it.key, (loadServiceForName<ResolverFactory>(it.value.factory) ?: throw IllegalArgumentException("Failed to find resolver factory implementation for '${it.value.factory}'.")).newResolver(schema, it.value.parameters))
+        config.resolvers.forEach { (name, resolverConfig) ->
+            schema.addResolver(name, (loadServiceForName<ResolverFactory>(resolverConfig.factory) ?: throw IllegalArgumentException("Failed to find resolver factory implementation for '${resolverConfig.factory}'.")).newResolver(schema, resolverConfig.parameters))
         }
         config.exporters.forEach { (name, exporterConfig) ->
             schema.addExporter(
@@ -68,7 +68,7 @@ class SchemaManager {
                 exporterConfig.resolverName
             )
         }
-        config.extractionPipelines.forEach() {(name, extractionPipelineConfig) ->
+        config.extractionPipelines.forEach {(name, extractionPipelineConfig) ->
             val ingestionConfig = IngestionConfig.read(Paths.get(extractionPipelineConfig.path))
                 ?: throw IllegalArgumentException("Failed to read pipeline configuration from '${extractionPipelineConfig.path}'.")
             if (ingestionConfig.schema != schema.name) {

--- a/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
+++ b/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
@@ -31,8 +31,8 @@ fun main(args: Array<String>) {
 
     /* Setup schema manager. */
     val manager = SchemaManager()
-    for ((_, schemaConfig) in config.schemas) {
-        manager.load(schemaConfig)
+    for ((name, schemaConfig) in config.schemas) {
+        manager.load(name, schemaConfig)
     }
 
     /* Execution server singleton for this instance. */

--- a/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
+++ b/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
@@ -31,7 +31,8 @@ fun main(args: Array<String>) {
 
     /* Setup schema manager. */
     val manager = SchemaManager()
-    for (schema in config.schemas) {
+    for ((name, schema) in config.schemas) {
+        schema.name = name
         manager.load(schema)
     }
 

--- a/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
+++ b/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
@@ -31,9 +31,8 @@ fun main(args: Array<String>) {
 
     /* Setup schema manager. */
     val manager = SchemaManager()
-    for ((name, schema) in config.schemas) {
-        schema.name = name
-        manager.load(schema)
+    for ((_, schemaConfig) in config.schemas) {
+        manager.load(schemaConfig)
     }
 
     /* Execution server singleton for this instance. */

--- a/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/config/ServerConfig.kt
+++ b/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/config/ServerConfig.kt
@@ -5,6 +5,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.jsonObject
 import org.vitrivr.engine.core.config.schema.SchemaConfig
 import java.nio.file.Files
 import java.nio.file.Path
@@ -32,8 +33,20 @@ data class ServerConfig(
          * @return [ServerConfig] or null, if an error occurred.
          */
         fun read(path: Path): ServerConfig? = try {
-            Files.newInputStream(path, StandardOpenOption.READ).use {
-                Json.decodeFromStream<ServerConfig>(it)
+            Files.newInputStream(path, StandardOpenOption.READ).use { inputStream ->
+                val rawJson = inputStream.bufferedReader().use { it.readText() }
+                val jsonObject = Json.parseToJsonElement(rawJson).jsonObject
+
+                val apiConfig = jsonObject["api"]?.let {
+                    Json.decodeFromJsonElement<ApiConfig>(ApiConfig.serializer(), it)
+                } ?: ApiConfig()
+
+                val schemasJsonObject = jsonObject["schemas"]?.jsonObject ?: return null
+                val schemas = schemasJsonObject.map { (name, jsonElement) ->
+                    name to SchemaConfig.fromJsonWithName(jsonElement, name)
+                }.toMap()
+
+                ServerConfig(api = apiConfig, schemas = schemas)
             }
         } catch (e: Throwable) {
             logger.error(e) { "Failed to read configuration from $path due to an exception." }

--- a/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/config/ServerConfig.kt
+++ b/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/config/ServerConfig.kt
@@ -19,7 +19,7 @@ data class ServerConfig(
     val api: ApiConfig = ApiConfig(),
 
     /** List of [SchemaConfig] managed by this [ServerConfig]. */
-    val schemas: List<SchemaConfig>
+    val schemas: Map<String, SchemaConfig>
 ) {
     companion object {
         /** Default path to fall back to. */


### PR DESCRIPTION
In the schema config, the changes in this PR remove the "name" property for schemas, fields, exporters, and extractionPipelines, and instead places the name as a key in a map. Addresses issue #80 