### PR TITLE
Cli Command to migrate between databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ thumbnails/
 # OpenAPI generated code
 openapi
 thumbnails*
+
+vitrivr-json/

--- a/example-configs/ingestion/migration/video-ct.json
+++ b/example-configs/ingestion/migration/video-ct.json
@@ -1,0 +1,107 @@
+{
+  "schema": "vitrivr-ct",
+  "context": {
+    "contentFactory": "InMemoryContentFactory",
+    "resolverName":"disk",
+
+    "local": {
+      "clip": {
+        "contentSources": "selector"
+      },
+      "averagecolor": {
+        "contentSources": "selector"
+      },
+      "content": {
+        "path": "../cache"
+      },
+      "thumbnail": {
+        "contentSources": "selector",
+        "maxSideResolution": "400",
+        "mimeType": "JPG"
+      },
+      "selector":{
+        "contentSources": "decoder"
+      },
+      "enumerator": {
+        "path": "./media",
+        "depth": "3"
+      },
+      "decoder": {
+        "timeWindowMs": "6000"
+      },
+      "filter": {
+        "type": "SOURCE:VIDEO"
+      },
+      "path": {
+        "field": "file"
+      }
+    }
+  },
+  "operators": {
+    "enumerator": {
+      "type": "ENUMERATOR",
+      "factory": "FileSystemEnumerator",
+      "mediaTypes": ["VIDEO"]
+    },
+    "decoder": {
+      "type": "DECODER",
+      "factory": "VideoDecoder"
+    },
+    "metadata":{
+      "type": "EXTRACTOR",
+      "fieldName": "video"
+    },
+    "source":{
+      "type": "EXTRACTOR",
+      "fieldName": "file"
+    },
+    "path": {
+      "type": "TRANSFORMER",
+      "factory":"DescriptorAsContentTransformer"
+    },
+    "selector": {
+      "type": "TRANSFORMER",
+      "factory": "LastContentAggregator"
+    },
+    "time": {
+      "type": "EXTRACTOR",
+      "fieldName": "time"
+    },
+    "averagecolor": {
+      "type": "EXTRACTOR",
+      "fieldName": "averagecolor"
+    },
+    "clip": {
+      "type": "EXTRACTOR",
+      "fieldName": "clip"
+    },
+    "thumbnail": {
+      "type": "EXPORTER",
+      "exporterName": "thumbnail"
+    },
+    "filter": {
+      "type": "TRANSFORMER",
+      "factory": "TypeFilterTransformer"
+    }
+  },
+  "operations": {
+    "enumerator": {"operator": "enumerator"},
+    "decoder": {"operator": "decoder", "inputs": ["enumerator"]},
+    "path": {"operator": "path", "inputs": ["decoder"]},
+    "metadata": {"operator": "metadata", "inputs": ["path"], "merge": "COMBINE"},
+
+    "source": {"operator": "source", "inputs": ["metadata"]},
+
+    "time": {"operator": "time", "inputs": ["source"]},
+    "selector": {"operator": "selector", "inputs": ["time"]},
+
+    "thumbnail": {"operator": "thumbnail", "inputs": ["selector"]},
+
+    "clip": {"operator": "clip", "inputs": ["thumbnail"]},
+    "filter": {"operator": "filter","inputs": ["clip"],"merge": "MERGE"}
+  },
+  "output": [
+    "filter"
+  ],
+  "mergeType": "MERGE"
+}

--- a/example-configs/ingestion/migration/video-json.json
+++ b/example-configs/ingestion/migration/video-json.json
@@ -1,0 +1,107 @@
+{
+  "schema": "vitrivr-json",
+  "context": {
+    "contentFactory": "InMemoryContentFactory",
+    "resolverName":"disk",
+
+    "local": {
+      "clip": {
+        "contentSources": "selector"
+      },
+      "averagecolor": {
+        "contentSources": "selector"
+      },
+      "content": {
+        "path": "../cache"
+      },
+      "thumbnail": {
+        "contentSources": "selector",
+        "maxSideResolution": "400",
+        "mimeType": "JPG"
+      },
+      "selector":{
+        "contentSources": "decoder"
+      },
+      "enumerator": {
+        "path": "./media",
+        "depth": "3"
+      },
+      "decoder": {
+        "timeWindowMs": "6000"
+      },
+      "filter": {
+        "type": "SOURCE:VIDEO"
+      },
+      "path": {
+        "field": "file"
+      }
+    }
+  },
+  "operators": {
+    "enumerator": {
+      "type": "ENUMERATOR",
+      "factory": "FileSystemEnumerator",
+      "mediaTypes": ["VIDEO"]
+    },
+    "decoder": {
+      "type": "DECODER",
+      "factory": "VideoDecoder"
+    },
+    "metadata":{
+      "type": "EXTRACTOR",
+      "fieldName": "video"
+    },
+    "source":{
+      "type": "EXTRACTOR",
+      "fieldName": "file"
+    },
+    "path": {
+      "type": "TRANSFORMER",
+      "factory":"DescriptorAsContentTransformer"
+    },
+    "selector": {
+      "type": "TRANSFORMER",
+      "factory": "LastContentAggregator"
+    },
+    "time": {
+      "type": "EXTRACTOR",
+      "fieldName": "time"
+    },
+    "averagecolor": {
+      "type": "EXTRACTOR",
+      "fieldName": "averagecolor"
+    },
+    "clip": {
+      "type": "EXTRACTOR",
+      "fieldName": "clip"
+    },
+    "thumbnail": {
+      "type": "EXPORTER",
+      "exporterName": "thumbnail"
+    },
+    "filter": {
+      "type": "TRANSFORMER",
+      "factory": "TypeFilterTransformer"
+    }
+  },
+  "operations": {
+    "enumerator": {"operator": "enumerator"},
+    "decoder": {"operator": "decoder", "inputs": ["enumerator"]},
+    "path": {"operator": "path", "inputs": ["decoder"]},
+    "metadata": {"operator": "metadata", "inputs": ["path"], "merge": "COMBINE"},
+
+    "source": {"operator": "source", "inputs": ["metadata"]},
+
+    "time": {"operator": "time", "inputs": ["source"]},
+    "selector": {"operator": "selector", "inputs": ["time"]},
+
+    "thumbnail": {"operator": "thumbnail", "inputs": ["selector"]},
+
+    "clip": {"operator": "clip", "inputs": ["thumbnail"]},
+    "filter": {"operator": "filter","inputs": ["clip"],"merge": "MERGE"}
+  },
+  "output": [
+    "filter"
+  ],
+  "mergeType": "MERGE"
+}

--- a/example-configs/ingestion/migration/video-pg.json
+++ b/example-configs/ingestion/migration/video-pg.json
@@ -1,0 +1,107 @@
+{
+  "schema": "vitrivr-pg",
+  "context": {
+    "contentFactory": "InMemoryContentFactory",
+    "resolverName":"disk",
+
+    "local": {
+      "clip": {
+        "contentSources": "selector"
+      },
+      "averagecolor": {
+        "contentSources": "selector"
+      },
+      "content": {
+        "path": "../cache"
+      },
+      "thumbnail": {
+        "contentSources": "selector",
+        "maxSideResolution": "400",
+        "mimeType": "JPG"
+      },
+      "selector":{
+        "contentSources": "decoder"
+      },
+      "enumerator": {
+        "path": "./media",
+        "depth": "3"
+      },
+      "decoder": {
+        "timeWindowMs": "6000"
+      },
+      "filter": {
+        "type": "SOURCE:VIDEO"
+      },
+      "path": {
+        "field": "file"
+      }
+    }
+  },
+  "operators": {
+    "enumerator": {
+      "type": "ENUMERATOR",
+      "factory": "FileSystemEnumerator",
+      "mediaTypes": ["VIDEO"]
+    },
+    "decoder": {
+      "type": "DECODER",
+      "factory": "VideoDecoder"
+    },
+    "metadata":{
+      "type": "EXTRACTOR",
+      "fieldName": "video"
+    },
+    "source":{
+      "type": "EXTRACTOR",
+      "fieldName": "file"
+    },
+    "path": {
+      "type": "TRANSFORMER",
+      "factory":"DescriptorAsContentTransformer"
+    },
+    "selector": {
+      "type": "TRANSFORMER",
+      "factory": "LastContentAggregator"
+    },
+    "time": {
+      "type": "EXTRACTOR",
+      "fieldName": "time"
+    },
+    "averagecolor": {
+      "type": "EXTRACTOR",
+      "fieldName": "averagecolor"
+    },
+    "clip": {
+      "type": "EXTRACTOR",
+      "fieldName": "clip"
+    },
+    "thumbnail": {
+      "type": "EXPORTER",
+      "exporterName": "thumbnail"
+    },
+    "filter": {
+      "type": "TRANSFORMER",
+      "factory": "TypeFilterTransformer"
+    }
+  },
+  "operations": {
+    "enumerator": {"operator": "enumerator"},
+    "decoder": {"operator": "decoder", "inputs": ["enumerator"]},
+    "path": {"operator": "path", "inputs": ["decoder"]},
+    "metadata": {"operator": "metadata", "inputs": ["path"], "merge": "COMBINE"},
+
+    "source": {"operator": "source", "inputs": ["metadata"]},
+
+    "time": {"operator": "time", "inputs": ["source"]},
+    "selector": {"operator": "selector", "inputs": ["time"]},
+
+    "thumbnail": {"operator": "thumbnail", "inputs": ["selector"]},
+
+    "clip": {"operator": "clip", "inputs": ["thumbnail"]},
+    "filter": {"operator": "filter","inputs": ["clip"],"merge": "MERGE"}
+  },
+  "output": [
+    "filter"
+  ],
+  "mergeType": "MERGE"
+}

--- a/example-configs/schema/migration-schema.json
+++ b/example-configs/schema/migration-schema.json
@@ -1,0 +1,176 @@
+{
+  "schemas": {
+    "vitrivr-ct": {
+      "connection": {
+        "database": "CottontailConnectionProvider",
+        "parameters": {
+          "Host": "127.0.0.1",
+          "port": "1865"
+        }
+      },
+      "fields": {
+        "averagecolor": {
+          "factory": "AverageColor"
+        },
+        "file": {
+          "factory": "FileSourceMetadata"
+        },
+        "clip": {
+          "factory": "DenseEmbedding",
+          "parameters": {
+            "host": "http://10.34.64.84:8888/",
+            "model": "open-clip-vit-b32",
+            "length": "512",
+            "timeoutSeconds": "100",
+            "retries": "1000"
+          }
+        },
+        "time": {
+          "factory": "TemporalMetadata"
+        },
+        "video": {
+          "factory": "VideoSourceMetadata"
+        }
+      },
+      "resolvers": {
+        "disk": {
+          "factory": "DiskResolver",
+          "parameters": {
+            "location": "./example/thumbs"
+          }
+        }
+      },
+      "exporters": {
+        "thumbnail": {
+          "factory": "ThumbnailExporter",
+          "resolverName": "disk",
+          "parameters": {
+            "maxSideResolution": "300",
+            "mimeType": "JPG"
+          }
+        }
+      },
+      "extractionPipelines": {
+        "video": {
+          "path": "./example-configs/ingestion/migration/video-ct.json"
+        }
+      }
+    },
+
+    "vitrivr-pg": {
+      "connection": {
+        "database": "PgVectorConnectionProvider",
+        "parameters": {
+          "Host": "127.0.0.1",
+          "port": "5432",
+          "username": "postgres",
+          "password": "vitrivr"
+        }
+      },
+      "fields": {
+        "averagecolor": {
+          "factory": "AverageColor"
+        },
+        "file": {
+          "factory": "FileSourceMetadata"
+        },
+        "clip": {
+          "factory": "DenseEmbedding",
+          "parameters": {
+            "host": "http://10.34.64.84:8888/",
+            "model": "open-clip-vit-b32",
+            "length": "512",
+            "timeoutSeconds": "100",
+            "retries": "1000"
+          }
+        },
+        "time": {
+          "factory": "TemporalMetadata"
+        },
+        "video": {
+          "factory": "VideoSourceMetadata"
+        }
+      },
+      "resolvers": {
+        "disk": {
+          "factory": "DiskResolver",
+          "parameters": {
+            "location": "./example/thumbs"
+          }
+        }
+      },
+      "exporters": {
+        "thumbnail": {
+          "factory": "ThumbnailExporter",
+          "resolverName": "disk",
+          "parameters": {
+            "maxSideResolution": "300",
+            "mimeType": "JPG"
+          }
+        }
+      },
+      "extractionPipelines": {
+        "video": {
+          "path": "./example-configs/ingestion/migration/video-pg.json"
+        }
+      }
+    },
+
+
+    "vitrivr-json": {
+      "connection": {
+        "database": "JsonlConnectionProvider",
+        "parameters": {
+          "root": "."
+        }
+      },
+      "fields": {
+        "averagecolor": {
+          "factory": "AverageColor"
+        },
+        "file": {
+          "factory": "FileSourceMetadata"
+        },
+        "clip": {
+          "factory": "DenseEmbedding",
+          "parameters": {
+            "host": "http://10.34.64.84:8888/",
+            "model": "open-clip-vit-b32",
+            "length": "512",
+            "timeoutSeconds": "100",
+            "retries": "1000"
+          }
+        },
+        "time": {
+          "factory": "TemporalMetadata"
+        },
+        "video": {
+          "factory": "VideoSourceMetadata"
+        }
+      },
+      "resolvers": {
+        "disk": {
+          "factory": "DiskResolver",
+          "parameters": {
+            "location": "./example/thumbs"
+          }
+        }
+      },
+      "exporters": {
+        "thumbnail": {
+          "factory": "ThumbnailExporter",
+          "resolverName": "disk",
+          "parameters": {
+            "maxSideResolution": "300",
+            "mimeType": "JPG"
+          }
+        }
+      },
+      "extractionPipelines": {
+        "video": {
+          "path": "./example-configs/ingestion/migration/video-json.json"
+        }
+      }
+    }
+  }
+}

--- a/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/AbstractJsonlReader.kt
+++ b/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/AbstractJsonlReader.kt
@@ -42,6 +42,7 @@ abstract class AbstractJsonlReader<D : Descriptor<*>>(
 
     override fun getAll(): Sequence<D> {
 
+
         return BufferedReader(InputStreamReader(path.inputStream())).lineSequence().mapNotNull {
             try {
                 val list = Json.decodeFromString<AttributeContainerList>(it)

--- a/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/AbstractJsonlReader.kt
+++ b/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/AbstractJsonlReader.kt
@@ -41,9 +41,9 @@ abstract class AbstractJsonlReader<D : Descriptor<*>>(
     }
 
     override fun getAll(): Sequence<D> {
-
-
-        return BufferedReader(InputStreamReader(path.inputStream())).lineSequence().mapNotNull {
+        val ins = InputStreamReader(path.inputStream())
+        val br = BufferedReader(ins).lineSequence()
+        val mapped = br.mapNotNull {
             try {
                 val list = Json.decodeFromString<AttributeContainerList>(it)
                 return@mapNotNull toDescriptor(list)
@@ -55,7 +55,7 @@ abstract class AbstractJsonlReader<D : Descriptor<*>>(
                 null
             }
         }
-
+        return mapped
     }
 
     override fun queryAndJoin(query: Query): Sequence<Retrieved> {
@@ -72,7 +72,7 @@ abstract class AbstractJsonlReader<D : Descriptor<*>>(
     }
 
     override fun getForRetrievable(retrievableId: RetrievableId): Sequence<D> {
-        return getAll().filter { it.retrievableId == retrievableId}
+        return getAll().filter { it.retrievableId == retrievableId }
     }
 
     override fun getAllForRetrievable(retrievableIds: Iterable<RetrievableId>): Sequence<D> {

--- a/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/AbstractJsonlReader.kt
+++ b/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/AbstractJsonlReader.kt
@@ -41,9 +41,7 @@ abstract class AbstractJsonlReader<D : Descriptor<*>>(
     }
 
     override fun getAll(): Sequence<D> {
-        val ins = InputStreamReader(path.inputStream())
-        val br = BufferedReader(ins).lineSequence()
-        val mapped = br.mapNotNull {
+        return BufferedReader(InputStreamReader(path.inputStream())).lineSequence().mapNotNull {
             try {
                 val list = Json.decodeFromString<AttributeContainerList>(it)
                 return@mapNotNull toDescriptor(list)
@@ -55,7 +53,6 @@ abstract class AbstractJsonlReader<D : Descriptor<*>>(
                 null
             }
         }
-        return mapped
     }
 
     override fun queryAndJoin(query: Query): Sequence<Retrieved> {

--- a/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/retrievable/JsonlRetrievableReader.kt
+++ b/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/retrievable/JsonlRetrievableReader.kt
@@ -13,39 +13,18 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import kotlin.io.path.inputStream
 
-class JsonlRetrievableReader(
-    override val connection: JsonlConnection
-) : RetrievableReader {
+class JsonlRetrievableReader(override val connection: JsonlConnection) : RetrievableReader {
 
-    private val retrievablePath =
-        connection.schemaRoot.resolve(
-            "retrievables.jsonl"
-        )
-    private val connectionPath =
-        connection.schemaRoot.resolve(
-            "retrievable_connections.jsonl"
-        )
+    private val retrievablePath = connection.schemaRoot.resolve("retrievables.jsonl")
+    private val connectionPath = connection.schemaRoot.resolve("retrievable_connections.jsonl")
 
-    override fun get(
-        id: RetrievableId
-    ): Retrievable? =
-        getAll().firstOrNull { it.id == id }
+    override fun get(id: RetrievableId): Retrievable? = getAll().firstOrNull { it.id == id }
 
-    override fun exists(
-        id: RetrievableId
-    ): Boolean =
-        get(id) != null
+    override fun exists(id: RetrievableId): Boolean = get(id) != null
 
-    override fun getAll(
-        ids: Iterable<RetrievableId>
-    ): Sequence<Retrievable> {
-        val idSet =
-            ids.toSet()
-        return getAll().filter {
-            idSet.contains(
-                it.id
-            )
-        }
+    override fun getAll(ids: Iterable<RetrievableId>): Sequence<Retrievable> {
+        val idSet = ids.toSet()
+        return getAll().filter { idSet.contains(it.id) }
     }
 
     override fun getConnections(
@@ -53,69 +32,40 @@ class JsonlRetrievableReader(
         predicates: Collection<String>,
         objectIds: Collection<RetrievableId>
     ): Sequence<Triple<RetrievableId, String, RetrievableId>> {
-        val subIds =
-            subjectIds.toSet()
-        val predIds =
-            predicates.toSet()
-        val objIds =
-            objectIds.toSet()
+        val subIds = subjectIds.toSet()
+        val predIds = predicates.toSet()
+        val objIds = objectIds.toSet()
 
-        return BufferedReader(
-            InputStreamReader(
-                connectionPath.inputStream()
-            )
-        ).lineSequence()
-            .mapNotNull {
-                try {
-                    Json.decodeFromString<JsonlRelationship>(
-                        it
-                    )
-                } catch (se: SerializationException) {
-                    LOGGER.error(
-                        se
-                    ) { "Error during deserialization" }
-                    null
-                } catch (ie: IllegalArgumentException) {
-                    LOGGER.error(
-                        ie
-                    ) { "Error during deserialization" }
-                    null
-                }
+        return BufferedReader(InputStreamReader(connectionPath.inputStream())).lineSequence().mapNotNull {
+            try {
+                Json.decodeFromString<JsonlRelationship>(it)
+            } catch (se: SerializationException) {
+                LOGGER.error(se) { "Error during deserialization" }
+                null
+            } catch (ie: IllegalArgumentException) {
+                LOGGER.error(ie) { "Error during deserialization" }
+                null
             }
-            .filter {
-                (subIds.isEmpty() || subIds.contains(
-                    it.sub
-                )) &&
-                        (predIds.isEmpty() || predIds.contains(
-                            it.pred
-                        )) &&
-                        (objIds.isEmpty() || objIds.contains(
-                            it.obj
-                        ))
-            }
-            .map { it.toTriple() }
+        }.filter {
+            (subIds.isEmpty() || subIds.contains(it.sub)) &&
+                    (predIds.isEmpty() || predIds.contains(it.pred)) &&
+                    (objIds.isEmpty() || objIds.contains(it.obj))
+        }.map { it.toTriple() }
     }
 
     override fun getAll(): Sequence<Retrievable> {
-        val inputstream =retrievablePath.inputStream()
-        val br =BufferedReader(InputStreamReader(inputstream))
-        val tmp = br.lineSequence().mapNotNull {
-                    try {
-                        Json.decodeFromString<JsonlRetrievable>(it).toRetrieved()
-                    } catch (se: SerializationException) {
-                        LOGGER.error(se) { "Error during deserialization" }
-                        null
-                    } catch (ie: IllegalArgumentException) {
-                        LOGGER.error(ie) { "Error during deserialization" }
-                        null
-                    } catch (e: Exception) {
-                        LOGGER.error(e) { "Error during deserialization" }
-                        null
-                    }
-                }
-        return tmp
+        return BufferedReader(InputStreamReader(retrievablePath.inputStream())).lineSequence().mapNotNull {
+            try {
+                Json.decodeFromString<JsonlRetrievable>(it).toRetrieved()
+            } catch (se: SerializationException) {
+                LOGGER.error(se) { "Error during deserialization" }
+                null
+            } catch (ie: IllegalArgumentException) {
+                LOGGER.error(ie) { "Error during deserialization" }
+                null
+            }
+        }
     }
-
 
     override fun count(): Long =
         BufferedReader(InputStreamReader(retrievablePath.inputStream())).lineSequence().count().toLong()

--- a/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/scalar/ScalarJsonlReader.kt
+++ b/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/scalar/ScalarJsonlReader.kt
@@ -20,8 +20,8 @@ class ScalarJsonlReader(
     override fun toDescriptor(list: AttributeContainerList): ScalarDescriptor<*, *> {
 
         val map = list.list.associateBy { it.attribute.name }
-        val retrievableId = (map[DESCRIPTOR_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
-        val descriptorId = (map[RETRIEVABLE_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
+        val retrievableId = (map[RETRIEVABLE_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
+        val descriptorId = (map[DESCRIPTOR_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
         val value = map["value"]?.value!!.toValue()
 
         return when (prototype) {

--- a/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/struct/StructJsonlReader.kt
+++ b/vitrivr-engine-module-jsonl/src/main/kotlin/org/vitrivr/engine/database/jsonl/struct/StructJsonlReader.kt
@@ -26,8 +26,8 @@ class StructJsonlReader(
             ?: throw IllegalStateException("Provided type ${this.field.analyser.descriptorClass} does not have a primary constructor.")
         val valueMap = mutableMapOf<AttributeName, Value<*>>()
 
-        val retrievableId = (map[DESCRIPTOR_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
-        val descriptorId = (map[RETRIEVABLE_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
+        val retrievableId = (map[RETRIEVABLE_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
+        val descriptorId = (map[DESCRIPTOR_ID_COLUMN_NAME]?.value!!.toValue() as Value.UUIDValue).value
         val parameters: MutableList<Any?> = mutableListOf(
             descriptorId,
             retrievableId,

--- a/vitrivr-engine-module-pgvector/src/main/kotlin/org/vitrivr/engine/database/pgvector/retrievable/RetrievableReader.kt
+++ b/vitrivr-engine-module-pgvector/src/main/kotlin/org/vitrivr/engine/database/pgvector/retrievable/RetrievableReader.kt
@@ -120,6 +120,9 @@ class RetrievableReader(override val connection: PgVectorConnection): Retrievabl
             }
             query.append("$OBJECT_ID_COLUMN_NAME = ANY (?)")
         }
+        if (query.endsWith("WHERE ")) {
+            query.delete(query.length - 7, query.length)
+        }
 
         return sequence {
             try {

--- a/vitrivr-engine-server/build.gradle
+++ b/vitrivr-engine-server/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     /** vitrivr engine dependencies. */
     api project(':vitrivr-engine-index')
     api project(':vitrivr-engine-query')
+    api project(':vitrivr-engine-module-jsonl')
     api project(':vitrivr-engine-module-features')       /* TODO: This dependency is not necessary and only here to facilitate easy testing. */
     api project(':vitrivr-engine-module-cottontaildb')   /* TODO: This dependency is not necessary and only here to facilitate easy testing. */
     api project(':vitrivr-engine-module-pgvector')       /* TODO: This dependency is not necessary and only here to facilitate easy testing. */

--- a/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
+++ b/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/Main.kt
@@ -86,7 +86,7 @@ fun main(args: Array<String>) {
     /* Prepare CLI endpoint. */
     val cli = Cli(manager)
     for (schema in manager.listSchemas()) {
-        cli.register(SchemaCommand(schema, executor))
+        cli.register(SchemaCommand(schema, executor, manager))
     }
 
     /* Start the Javalin server. */

--- a/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/api/cli/commands/SchemaCommand.kt
+++ b/vitrivr-engine-server/src/main/kotlin/org/vitrivr/engine/server/api/cli/commands/SchemaCommand.kt
@@ -226,8 +226,8 @@ class SchemaCommand(private val schema: Schema, private val server: ExecutionSer
             zippedFields.forEach{ (currField, tarField) ->
                 val oldReader = currField.getReader()
                 val newWriter = tarField.getWriter()
-                val tmp = oldReader.getAll()
-                newWriter.addAll(tmp.toList())
+                val tmp = oldReader.getAll().toList()
+                newWriter.addAll(tmp)
             }
             logger.info{ "Migrated ${currentFields.size} fields." }
             logger.info{ "Migration complete."}


### PR DESCRIPTION
This PR adds a new `migrate-to` Cli command to migrate all contents of one schema to another. For example to easily migrate from an existing cottontail database to postgres.
Usage: `<origin-schema> migrate-to -n <target-schema>`

Both schemas need to be initialised `<schema> init` and contain the same entities.

Wiki: https://github.com/vitrivr/vitrivr-engine/wiki/Example#migration