### PR TITLE
Adjust Fulltext Search

### DIFF
--- a/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/Schema.kt
+++ b/vitrivr-engine-core/src/main/kotlin/org/vitrivr/engine/core/model/metamodel/Schema.kt
@@ -246,6 +246,14 @@ open class Schema(val name: String = "vitrivr", val connection: Connection) : Cl
          * @return [DescriptorWriter]
          */
         fun getWriter(): DescriptorWriter<D> = this.connection.getDescriptorWriter(this as Field<*, D>)
+
+
+        /**
+         * Convenience method to generate and return a prototypical [D] for this [Field].
+         *
+         * @return [D]
+         */
+        fun getPrototype(): D = this.analyser.prototype(this as Field<*, D>)
     }
 
     /**

--- a/vitrivr-engine-index/src/main/kotlin/org/vitrivr/engine/index/decode/FFmpegVideoDecoder.kt
+++ b/vitrivr-engine-index/src/main/kotlin/org/vitrivr/engine/index/decode/FFmpegVideoDecoder.kt
@@ -184,6 +184,10 @@ class FFmpegVideoDecoder : DecoderFactory {
             override fun consumeStreams(streams: MutableList<Stream>) {
                 this.videoStream = streams.firstOrNull { it.type == Stream.Type.VIDEO }
                 this.audioStream = streams.firstOrNull { it.type == Stream.Type.AUDIO }
+
+                /* Reset counters and flags. */
+                this@InFlowFrameConsumer.videoReady = !(this@InFlowFrameConsumer.videoStream != null && this@Instance.video)
+                this@InFlowFrameConsumer.audioReady = !(this@InFlowFrameConsumer.audioStream != null && this@Instance.audio)
             }
 
             /**
@@ -217,8 +221,7 @@ class FFmpegVideoDecoder : DecoderFactory {
                 }
 
                 /* If enough frames have been collected, emit them. */
-                if ((this@Instance.audio && this@InFlowFrameConsumer.videoReady && this@InFlowFrameConsumer.audioReady) ||
-                    (!this@Instance.audio && this@InFlowFrameConsumer.videoReady)) {
+                if (this@InFlowFrameConsumer.videoReady && this@InFlowFrameConsumer.audioReady) {
                     emit()
 
                     /* Reset counters and flags. */

--- a/vitrivr-engine-module-cottontaildb/src/main/kotlin/org/vitrivr/engine/plugin/cottontaildb/descriptors/scalar/ScalarDescriptorReader.kt
+++ b/vitrivr-engine-module-cottontaildb/src/main/kotlin/org/vitrivr/engine/plugin/cottontaildb/descriptors/scalar/ScalarDescriptorReader.kt
@@ -68,9 +68,10 @@ class ScalarDescriptorReader(field: Schema.Field<*, ScalarDescriptor<*, *>>, con
      * @return [Sequence] of [ScalarDescriptor]s.
      */
     private fun queryFulltext(query: SimpleFulltextQuery): Sequence<ScalarDescriptor<*, *>> {
+        val queryValue = query.value.value.split(" ").joinToString(" OR ", "(", ")") { "$it*" }
         val cottontailQuery = org.vitrivr.cottontail.client.language.dql.Query(this.entityName)
             .select("*")
-            .fulltext(VALUE_ATTRIBUTE_NAME, query.value.value, "score")
+            .fulltext(VALUE_ATTRIBUTE_NAME, queryValue, "score")
 
         if (query.limit < Long.MAX_VALUE) {
             cottontailQuery.limit(query.limit)

--- a/vitrivr-engine-module-cottontaildb/src/main/kotlin/org/vitrivr/engine/plugin/cottontaildb/descriptors/struct/StructDescriptorReader.kt
+++ b/vitrivr-engine-module-cottontaildb/src/main/kotlin/org/vitrivr/engine/plugin/cottontaildb/descriptors/struct/StructDescriptorReader.kt
@@ -102,7 +102,9 @@ class StructDescriptorReader(field: Schema.Field<*, StructDescriptor<*>>, connec
         for ((name, _) in this.fieldMap) {
             cottontailQuery.select(name)
         }
-        cottontailQuery.fulltext(query.attributeName!!, query.value.value, SCORE_COLUMN_NAME)
+
+        val queryValue = query.value.value.split(" ").joinToString(" OR ", "(", ")") { "$it*" }
+        cottontailQuery.fulltext(query.attributeName!!, queryValue, SCORE_COLUMN_NAME)
         if (query.limit < Long.MAX_VALUE) {
             cottontailQuery.limit(query.limit)
         }


### PR DESCRIPTION
`SimpleFulltextQuery` execution in PostgreSQL is adjusted as follows:
- Query terms are now tokenized and the individual words are ORed
- By default, Prefix-Matching is employed (i.e., every token is post-fixed with a wildcard)

I opened a PR for this, since the change might affect the behavior of existing logic.

In addition, I would propose to add a more powerful `AdvancedFulltextQuery` class in the future, for which the desired behavior can be steered. This is, however, not in scope for this PR.